### PR TITLE
chore: add build.yml for Github Actions

### DIFF
--- a/.github/scripts/setup_env.sh
+++ b/.github/scripts/setup_env.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -e
+
+# Helper function to write to GITHUB_ENV or stdout
+export_env() {
+    local key=$1
+    local val=$2
+    echo "$key=$val"
+    if [ -n "$GITHUB_ENV" ]; then
+        echo "$key=$val" >> "$GITHUB_ENV"
+    fi
+}
+
+echo ">>> Extracting Version Name..."
+if [ -f "app/build.gradle.kts" ]; then
+    # More robust regex: handles variable spacing around '='
+    VERSION_NAME=$(grep 'versionName' app/build.gradle.kts | sed -E 's/.*versionName[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/')
+else
+    echo "Error: app/build.gradle.kts not found!"
+    exit 1
+fi
+
+if [ -z "$VERSION_NAME" ]; then
+    echo "Error: Could not extract versionName from build.gradle.kts"
+    exit 1
+fi
+
+echo "Detected Version: $VERSION_NAME"
+export_env "VERSION_NAME" "$VERSION_NAME"
+
+echo ">>> Finding Build Tools..."
+# Try to detect ANDROID_SDK_ROOT or ANDROID_HOME
+if [ -n "${ANDROID_SDK_ROOT:-}" ]; then
+    SDK_ROOT="$ANDROID_SDK_ROOT"
+elif [ -n "${ANDROID_HOME:-}" ]; then
+    SDK_ROOT="$ANDROID_HOME"
+else
+    SDK_ROOT="/usr/local/lib/android/sdk"
+fi
+
+export_env "SDK_ROOT" "$SDK_ROOT"
+
+if [ -d "$SDK_ROOT/build-tools" ]; then
+    # Get the latest version
+    BUILD_TOOL_VERSION=$(ls "$SDK_ROOT/build-tools/" | sort -V | tail -n 1)
+else
+    echo "Error: build-tools not found in $SDK_ROOT"
+    exit 1
+fi
+
+if [ -z "$BUILD_TOOL_VERSION" ]; then
+    echo "Error: Could not determine latest build-tools version"
+    exit 1
+fi
+
+export_env "BUILD_TOOL_VERSION" "$BUILD_TOOL_VERSION"
+echo "Latest build tool version found: $BUILD_TOOL_VERSION"

--- a/.github/scripts/sign_apk.sh
+++ b/.github/scripts/sign_apk.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+set -euo pipefail # Strict mode
+
+# ### Variables ###
+PROJECT_NAME="AndroidAutoGLM"
+VERSION="${VERSION_NAME:?VERSION_NAME must be set}" # Exit if not set
+SDK_ROOT="${SDK_ROOT:?SDK_ROOT must be set}"
+BUILD_TOOL_VERSION="${BUILD_TOOL_VERSION:?BUILD_TOOL_VERSION must be set}"
+
+BUILD_TOOLS_PATH="$SDK_ROOT/build-tools/$BUILD_TOOL_VERSION"
+UNSIGNED_FILE="app/build/outputs/apk/release/app-release-unsigned.apk"
+ALIGNED_FILE="app/build/outputs/apk/release/app-release-aligned.apk"
+FINAL_ARTIFACT_NAME="${PROJECT_NAME}-${VERSION}-signed.apk"
+
+# Helper function to write to GITHUB_ENV or stdout
+export_env() {
+    local key=$1
+    local val=$2
+    echo "$key=$val"
+    if [ -n "$GITHUB_ENV" ]; then
+        echo "$key=$val" >> "$GITHUB_ENV"
+    fi
+}
+
+# ### Pre-checks ###
+if [ ! -f "$UNSIGNED_FILE" ]; then
+    echo "Error: Unsigned APK not found at $UNSIGNED_FILE" >&2
+    exit 1
+fi
+
+# ### Zipalign (common step) ###
+echo ">>> Zipaligning APK..."
+"$BUILD_TOOLS_PATH/zipalign" -v -f -p 4 "$UNSIGNED_FILE" "$ALIGNED_FILE"
+
+# ### Signing Logic ###
+SIGNED_SUCCESSFULLY=false
+
+# 1. Attempt Release Signing
+if [ -n "${SIGNING_KEY:-}" ] && [ -n "${KEY_ALIAS:-}" ] && [ -n "${KEY_STORE_PASSWORD:-}" ] && [ -n "${KEY_PASSWORD:-}" ]; then
+    echo ">>> Attempting to sign with Release Key..."
+    RELEASE_KEYSTORE="release.keystore"
+    SIGNED_FILE="app/build/outputs/apk/release/app-release-signed.apk"
+
+    # Decode keystore from secret
+    echo "$SIGNING_KEY" | base64 -d > "$RELEASE_KEYSTORE"
+
+    # Sign with apksigner
+    if "$BUILD_TOOLS_PATH/apksigner" sign \
+      --ks "$RELEASE_KEYSTORE" \
+      --ks-key-alias "$KEY_ALIAS" \
+      --ks-pass "pass:$KEY_STORE_PASSWORD" \
+      --key-pass "pass:$KEY_PASSWORD" \
+      --out "$SIGNED_FILE" \
+      "$ALIGNED_FILE"; then
+        
+        mv "$SIGNED_FILE" "$FINAL_ARTIFACT_NAME"
+        SIGNED_SUCCESSFULLY=true
+        echo "Successfully signed with Release Key."
+    else
+        echo "Warning: Failed to sign with Release Key, falling back to debug..." >&2
+    fi
+
+    # Cleanup
+    rm -f "$RELEASE_KEYSTORE"
+else
+    echo ">>> Release secrets not found, skipping release signing."
+fi
+
+# 2. Fallback to Debug Signing
+if ! $SIGNED_SUCCESSFULLY; then
+    echo ">>> Signing with Debug Key..."
+    DEBUG_KEYSTORE="debug.keystore"
+    DEBUG_SIGNED_APK="app/build/outputs/apk/release/app-release-signed-debug.apk"
+    
+    # Generate Debug Keystore if not exists
+    if [ ! -f "$DEBUG_KEYSTORE" ]; then
+        keytool -genkey -v -keystore "$DEBUG_KEYSTORE" -storepass android -alias androiddebugkey \
+                -keypass android -keyalg RSA -keysize 2048 -validity 10000 \
+                -dname "CN=Android Debug,O=Android,C=US"
+    fi
+
+    # Sign with debug key
+    if "$BUILD_TOOLS_PATH/apksigner" sign --ks "$DEBUG_KEYSTORE" --ks-pass pass:android --key-pass pass:android --out "$DEBUG_SIGNED_APK" "$ALIGNED_FILE"; then
+        mv "$DEBUG_SIGNED_APK" "$FINAL_ARTIFACT_NAME"
+        SIGNED_SUCCESSFULLY=true
+        echo "Successfully signed with Debug Key."
+    else
+        echo "Error: Failed to sign with debug key." >&2
+        exit 1 # Fatal error if even debug signing fails
+    fi
+fi
+
+# ### Final Steps ###
+if $SIGNED_SUCCESSFULLY; then
+    echo ">>> Finalizing artifact..."
+    export_env "ARTIFACT_PATH" "$FINAL_ARTIFACT_NAME"
+    echo "Artifact ready at: $FINAL_ARTIFACT_NAME"
+    # Cleanup intermediate files
+    rm -f "$ALIGNED_FILE"
+else
+    echo "Error: No APK was signed successfully." >&2
+    exit 1
+fi

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,55 @@
+name: Build Android Universal APK
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        lfs: true
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: gradle
+
+    - name: Grant execute permission for scripts and gradlew
+      run: chmod +x gradlew .github/scripts/*.sh
+
+    - name: Setup Environment (Version & Build Tools)
+      run: .github/scripts/setup_env.sh
+
+    - name: Create local.properties
+      run: |
+        if [ -n "${{ secrets.ZHIPU_API_KEY }}" ]; then
+          echo "ZHIPU_API_KEY=${{ secrets.ZHIPU_API_KEY }}" > local.properties
+        fi
+
+    - name: Build Release APK
+      run: ./gradlew assembleRelease
+
+    - name: Sign and Prepare APK
+      id: sign_apk
+      run: .github/scripts/sign_apk.sh
+      env:
+        SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+        KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+        KEY_STORE_PASSWORD: ${{ secrets.KEY_STORE_PASSWORD }}
+        KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+
+    - name: Upload APK
+      uses: actions/upload-artifact@v4
+      with:
+        name: android-autoglm-apk
+        path: ${{ env.ARTIFACT_PATH }}


### PR DESCRIPTION
# Pull Request: Add GitHub Actions for APK Signing

## Summary
This PR adds GitHub Actions workflow for automated APK building and signing. The workflow:
- Builds the Android application, with or without predefined `DEFAULT_API_KEY`
- Signs the APK using either release or debug keys
- Uploads the signed APK as an artifact

## Changes
### 1. GitHub Actions Workflow
- **File**: `.github/workflows/build.yml`
- **New Features**:
  - Added APK signing step using `sign_apk.sh` script
  - Configured artifact upload for the signed APK
  - Added environment setup step using `setup_env.sh`

### 2. APK Signing Script
- **File**: `.github/scripts/sign_apk.sh`
- **Functionality**:
  - Attempts release signing with provided secrets (preferred)
  - Falls back to debug signing if release secrets are missing
  - Uses `apksigner` for secure APK signing
  - Handles zipalign for optimal APK performance

### 3. Environment Setup Script
- **File**: `.github/scripts/setup_env.sh`
- **Functionality**:
  - Extracts version name from `build.gradle.kts`
  - Detects and sets Android SDK root path
  - Finds the latest build tools version

## Configuration

### 1. API Key Configuration
The application supports API Key configuration for accessing Zhipu AI services. The API Key can be predefined as Github Secret:

- **Secret Name**: `ZHIPU_API_KEY`
- **Value**: Your Zhipu AI API Key

The workflow automatically creates `local.properties` with the API Key during build.

### 2. Signature Configuration
To enable release signing, you need to configure the following secrets in your GitHub repository:

#### Required Secrets
1. **`SIGNING_KEY`** - Base64 encoded keystore file
2. **`KEY_ALIAS`** - Alias for the signing key
3. **`KEY_STORE_PASSWORD`** - Keystore password
4. **`KEY_PASSWORD`** - Key password

### GitHub Secrets Configuration Steps

#### Step 1: Generate and Configure Release Keystore (if needed)
```bash
# Generate keystore
keytool -genkey -v -keystore release.keystore -storepass YOUR_STORE_PASSWORD -alias YOUR_ALIAS -keypass YOUR_KEY_PASSWORD -keyalg RSA -keysize 2048 -validity 10000 -dname "CN=Your Name, O=Your Organization, C=Your Country"

# Convert to Base64
base64 -w 0 release.keystore > release.keystore.base64

# Copy the Base64 content and set as SIGNING_KEY secret
```

#### Step 2: Access Repository Settings
1. Go to your GitHub repository
2. Click on **Settings** → **Secrets and variables** → **Actions**

#### Step 3: Add Repository Secrets
1. Click **New repository secret**
2. Enter the secret name (e.g., `SIGNING_KEY`)
3. Paste the secret value
4. Click **Add secret**

Repeat for all required secrets:
- `SIGNING_KEY`: Base64 encoded keystore
- `KEY_ALIAS`: Your key alias
- `KEY_STORE_PASSWORD`: Keystore password
- `KEY_PASSWORD`: Key password
- `ZHIPU_API_KEY`: Your Zhipu AI API Key

### Workflow Execution
The workflow runs on:
- Push to `main` branch
- Pull requests to `main` branch
- Manual workflow dispatch

### Signing Process
1. **Release Signing** (preferred):
   - Uses provided secrets for signing
   - Produces a properly signed release APK

2. **Debug Signing** (fallback):
   - Generated automatically if release secrets are missing
   - Uses default debug keystore

### Output
The signed APK is uploaded as an artifact named `android-autoglm-apk` and can be downloaded from the workflow run.

## Benefits
- Automated builds and signing for every push/PR
- Secure release signing using GitHub Secrets
- Fallback to debug signing for development
- Consistent build environment using GitHub Actions

## Testing
To test the workflow:
1. Push changes to the `main` branch or create a PR
2. Monitor the GitHub Actions run
3. Download the signed APK from the artifacts section
