### PR TITLE
fix: make API URL description multilingual

### DIFF
--- a/app/src/main/java/com/sidhu/androidautoglm/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/sidhu/androidautoglm/ui/SettingsScreen.kt
@@ -258,8 +258,8 @@ fun SettingsScreen(
                             placeholder = { Text(stringResource(R.string.base_url_placeholder)) },
                             supportingText = {
                                 Text(
-                                    text = if (newIsGemini) "示例: https://generativelanguage.googleapis.com" 
-                                           else "示例: https://api.deepseek.com 或 https://api.deepseek.com/v1 (请勿包含 /chat/completions)",
+                                    text = if (newIsGemini) stringResource(R.string.base_url_hint_gemini) 
+                                           else stringResource(R.string.base_url_hint_openai),
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant
                                 )

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -25,6 +25,8 @@
     <string name="base_url_label">Base URL</string>
     <string name="enter_base_url">填入 Base URL</string>
     <string name="base_url_placeholder">https://open.bigmodel.cn/api/paas/v4</string>
+    <string name="base_url_hint_gemini">示例: https://generativelanguage.googleapis.com</string>
+    <string name="base_url_hint_openai">示例: https://api.deepseek.com 或 https://api.deepseek.com/v1 (请勿包含 /chat/completions)</string>
     <string name="model_name_label">模型名称</string>
     <string name="enter_model_name">填入模型名称</string>
     <string name="model_name_placeholder">autoglm-phone</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -25,6 +25,8 @@
     <string name="base_url_label">Base URL</string>
     <string name="enter_base_url">Enter Base URL</string>
     <string name="base_url_placeholder">https://open.bigmodel.cn/api/paas/v4</string>
+    <string name="base_url_hint_gemini">Example: https://generativelanguage.googleapis.com</string>
+    <string name="base_url_hint_openai">Example: https://api.deepseek.com or https://api.deepseek.com/v1 (Do not include /chat/completions)</string>
     <string name="model_name_label">Model Name</string>
     <string name="enter_model_name">Enter Model Name</string>
     <string name="model_name_placeholder">autoglm-phone</string>


### PR DESCRIPTION
This PR fixes hardcoded text in the API URL input field by moving the hint text to string resources, enabling proper internationalization support.

Changes:
- SettingsScreen.kt: Replaced hardcoded hint text with stringResource() references
    - Gemini URL hint now uses R.string.base_url_hint_gemini
    - OpenAI-compatible URL hint now uses R.string.base_url_hint_openai
- strings.xml: Added English hint strings for both URL formats
- values-zh/strings.xml: Added Chinese translations for the hint strings