### PR TITLE
fix: improve overlay hide reliability

### DIFF
--- a/app/src/main/java/com/sidhu/androidautoglm/FloatingWindowController.kt
+++ b/app/src/main/java/com/sidhu/androidautoglm/FloatingWindowController.kt
@@ -144,12 +144,21 @@ class FloatingWindowController(private val context: Context) : LifecycleOwner, V
         _isTaskRunning = running
     }
 
-    fun setScreenshotMode(isScreenshotting: Boolean) {
-        if (!isShowing || floatView == null) return
-        
+    /**
+     * Sets screenshot mode for the floating window.
+     *
+     * @param isScreenshotting True to hide window, false to show
+     * @param onComplete Optional callback invoked when layout is complete (if provided, waits for layout)
+     */
+    fun setScreenshotMode(isScreenshotting: Boolean, onComplete: (() -> Unit)? = null) {
+        if (!isShowing || floatView == null) {
+            onComplete?.invoke()
+            return
+        }
+
         try {
             floatView?.visibility = if (isScreenshotting) android.view.View.GONE else android.view.View.VISIBLE
-            
+
             // Update flags to ensure touches pass through when hidden
             if (isScreenshotting) {
                 windowParams.flags = windowParams.flags or WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE
@@ -161,8 +170,23 @@ class FloatingWindowController(private val context: Context) : LifecycleOwner, V
                 windowParams.height = WindowManager.LayoutParams.WRAP_CONTENT
             }
             windowManager.updateViewLayout(floatView, windowParams)
+
+            // If callback provided, wait for layout to complete
+            if (onComplete != null) {
+                floatView?.viewTreeObserver?.addOnGlobalLayoutListener(object : android.view.ViewTreeObserver.OnGlobalLayoutListener {
+                    override fun onGlobalLayout() {
+                        // Remove listener to avoid multiple calls
+                        floatView?.viewTreeObserver?.removeOnGlobalLayoutListener(this)
+                        // Post to end of queue to ensure frame is rendered
+                        android.os.Handler(android.os.Looper.getMainLooper()).post {
+                            onComplete.invoke()
+                        }
+                    }
+                })
+            }
         } catch (e: Exception) {
             e.printStackTrace()
+            onComplete?.invoke()
         }
     }
 


### PR DESCRIPTION
## Summary

- Improve overlay hide/show reliability by replacing fixed delays with callback-based async waiting
- Refactor timing control for screenshot and gesture operations to ensure overlay state changes complete before execution

## Problem Statement

The original code used fixed delays (150ms) to wait for UI updates when hiding the floating window before screenshots and gesture operations. This approach had several issues:

1. Unreliable timing: Fixed delays cannot guarantee the overlay is actually hidden, which may result in screenshots still containing the overlay or gestures being intercepted by the overlay on some devices
2. Resource waste: Always waits 150ms regardless of actual layout completion time
3. Missing error handling: Screenshot operations had no timeout mechanism and could block indefinitely

## Changes Overview

1. Callback-based Window State Management
  - setScreenshotMode() now accepts an optional onComplete callback
  - Uses ViewTreeObserver.OnGlobalLayoutListener to detect when layout is complete
  - Eliminates hardcoded delay(150) and CountDownLatch waits
2. Suspend Function Refactoring
  - performTap(), performSwipe(), performLongPress() converted to suspend functions
  - Gesture completion is now properly awaited via GestureResultCallback
  - Floating window visibility is synchronized with gesture lifecycle
3. API Improvements
  - New setFloatingWindowVisibleAndWait() - waits for layout completion
  - New setFloatingWindowVisible() - fire-and-forget variant
  - Better separation between temporary hiding and permanent removal
