### PR TITLE
fix: resolve stop task race condition with proper coroutine cancellation

### DIFF
--- a/app/src/main/java/com/sidhu/androidautoglm/network/ModelClient.kt
+++ b/app/src/main/java/com/sidhu/androidautoglm/network/ModelClient.kt
@@ -12,6 +12,7 @@ import retrofit2.http.Header
 import retrofit2.http.POST
 import java.io.ByteArrayOutputStream
 import java.util.concurrent.TimeUnit
+import kotlin.coroutines.cancellation.CancellationException
 
 interface OpenAIApi {
     @POST("chat/completions")
@@ -148,6 +149,9 @@ class ModelClient(
                 }
                 return "Error: ${response.code()} $errorMessage"
             }
+        } catch (e: CancellationException) {
+            // Rethrow cancellation to let the ViewModel handle it properly
+            throw e
         } catch (e: Exception) {
             Log.e("AutoGLM_Debug", "Gemini API Exception", e)
             val errorMessage = when (e) {
@@ -210,6 +214,9 @@ class ModelClient(
                 }
                 return "Error: ${response.code()} $errorMessage"
             }
+        } catch (e: CancellationException) {
+            // Rethrow cancellation to let the ViewModel handle it properly
+            throw e
         } catch (e: Exception) {
             Log.e("ModelClient", "Exception", e)
             return "Error: ${e.message}"


### PR DESCRIPTION
## Summary
- Fixes race condition when stopping a running task
- Implements proper coroutine cancellation with Job management
- Prevents task from continuing execution after stop button is clicked

## Details

Previously, calling `stopTask()` only updated the UI state but didn't cancel the underlying coroutines. This caused a race condition where:

1. User clicks stop
2. `isRunning` is set to `false`
3. But the coroutine continues executing steps
4. Steps may still execute if the loop condition wasn't checked yet

### Changes Made:

**ChatViewModel.kt:**
- Added `currentTaskJob` to track and cancel the running task
- `stopTask()` now calls `job.cancel()` to properly cancel coroutines
- Loop condition changed from `_uiState.value.isRunning` to `isActive` (kotlinx.coroutines property that respects cancellation)
- Added `ensureActive()` checkpoint before executing actions
- `CancellationException` is caught separately and treated as expected stop (not an error)
- Error state is explicitly cleared when stopping

**ModelClient.kt:**
- Added `CancellationException` handling that rethrows the exception
- This allows cancellation to propagate up to the ViewModel's try-catch block
